### PR TITLE
Added the implementation for EBS volume discovery on Windows

### DIFF
--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	ebsnvmeIDTimeoutDuration = 5 * time.Second
-	ebsResourceKeyPrefix     = "ebs-volume:"
-	ScanPeriod               = 500 * time.Millisecond
+	ebsVolumeDiscoveryTimeout = 5 * time.Second
+	ebsResourceKeyPrefix      = "ebs-volume:"
+	ScanPeriod                = 500 * time.Millisecond
 )
 
 var (

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery.go
@@ -15,10 +15,12 @@ package resource
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -31,31 +33,37 @@ var (
 	ErrInvalidVolumeID = errors.New("EBS volume IDs do not match")
 )
 
-// EBSDiscoveryClient is used to scan and validate if an EBS volume is attached on the host instance.
 type EBSDiscoveryClient struct {
 	ctx context.Context
 }
 
-// NewDiscoveryClient creates a new EBSDiscoveryClient object
-func NewDiscoveryClient(ctx context.Context) EBSDiscovery {
+func NewDiscoveryClient(ctx context.Context) *EBSDiscoveryClient {
 	return &EBSDiscoveryClient{
 		ctx: ctx,
 	}
 }
 
 // ScanEBSVolumes will iterate through the entire list of pending EBS volume attachments within the agent state and checks if it's attached on the host.
-func ScanEBSVolumes[T GenericEBSAttachmentObject](pendingAttachments map[string]T, dc EBSDiscovery) []string {
+func ScanEBSVolumes[T GenericEBSAttachmentObject](t map[string]T, dc EBSDiscovery) []string {
 	var err error
 	var foundVolumes []string
-	for key, ebs := range pendingAttachments {
+	for key, ebs := range t {
 		volumeId := strings.TrimPrefix(key, ebsResourceKeyPrefix)
 		deviceName := ebs.GetAttachmentProperties(DeviceName)
 		err = dc.ConfirmEBSVolumeIsAttached(deviceName, volumeId)
 		if err != nil {
-			if !errors.Is(err, ErrInvalidVolumeID) {
-				err = fmt.Errorf("%w; failed to confirm if EBS volume is attached to the host", err)
+			if err == ErrInvalidVolumeID || errors.Cause(err) == ErrInvalidVolumeID {
+				logger.Warn("Found a different EBS volume attached to the host. Expected EBS volume:", logger.Fields{
+					"volumeId":   volumeId,
+					"deviceName": deviceName,
+				})
+			} else {
+				logger.Warn("Failed to confirm if EBS volume is attached to the host. ", logger.Fields{
+					"volumeId":   volumeId,
+					"deviceName": deviceName,
+					"error":      err,
+				})
 			}
-			ebs.SetError(err)
 			continue
 		}
 		foundVolumes = append(foundVolumes, key)

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -44,7 +44,7 @@ type BDChild struct {
 // 2. On xen-based instance we only check by the device name.
 func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
 	var lsblkOut LsblkOutput
-	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsnvmeIDTimeoutDuration)
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsVolumeDiscoveryTimeout)
 	defer cancel()
 
 	// The lsblk command will output the name and volume ID of all block devices on the host in JSON format

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -16,6 +16,108 @@
 
 package resource
 
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+const (
+	volumeDiscoveryTimeoutDuration = 5 * time.Second
+	diskNumberOffset               = 0
+	volumeIdOffset                 = 1
+	deviceNameOffset               = 2
+	volumeInfoLength               = 3
+)
+
 func (api EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, volumeDiscoveryTimeoutDuration)
+	defer cancel()
+	output, err := exec.CommandContext(ctxWithTimeout,
+		"C:\\PROGRAMDATA\\Amazon\\Tools\\ebsnvme-id.exe").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run ebsnvme-id.exe: %s", string(output))
+	}
+
+	_, err = parseExecutableOutput(output, volumeID, deviceName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse ebsnvme-id.exe output for volumeID: %s and deviceName: %s",
+			volumeID, deviceName)
+	}
+
+	log.Info(fmt.Sprintf("found volume with volumeID: %s and deviceName: %s", volumeID, deviceName))
+
 	return nil
+}
+
+// parseExecutableOutput parses the output of `ebsnvme-id.exe` and returns the volumeId.
+func parseExecutableOutput(output []byte, candidateVolumeId string, candidateDeviceName string) (string, error) {
+	/* The output of the ebsnvme-id.exe is emitted like the following:
+	Disk Number: 0
+	Volume ID: vol-0a1234f340444abcd
+	Device Name: sda1
+
+	Disk Number: 1
+	Volume ID: vol-abcdef1234567890a
+	Device Name: /dev/sdf */
+
+	out := string(output)
+	// Replace double line with a single line and split based on single line
+	volumeInfo := strings.Split(strings.Replace(string(out), "\r\n\r\n", "\r\n", -1), "\r\n")
+
+	if len(volumeInfo) < volumeInfoLength {
+		return "", errors.New("cannot find the volume ID. Encountered error message: " + out)
+	}
+
+	//Read every 3 lines of disk information
+	for volumeIndex := 0; volumeIndex <= len(volumeInfo)-volumeInfoLength; volumeIndex = volumeIndex + volumeInfoLength {
+		_, volumeId, deviceName, err := parseSet(volumeInfo[volumeIndex : volumeIndex+volumeInfoLength])
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to parse the output for volumeID: %s and deviceName: %s. "+
+				"Output:%s", candidateVolumeId, candidateDeviceName, out)
+		}
+
+		if volumeId == candidateVolumeId && deviceName == candidateDeviceName {
+			return volumeId, nil
+		}
+
+	}
+
+	return "", errors.New("cannot find the volume ID:" + candidateVolumeId)
+}
+
+// parseSet parses the single volume information that is 3 lines long
+func parseSet(lines []string) (string, string, string, error) {
+	if len(lines) != 3 {
+		return "", "", "", errors.New("the number of entries in the volume information is insufficient to parse. Expected 3 lines")
+	}
+
+	diskNumber, err := parseValue(lines[diskNumberOffset], "Disk Number:")
+	if err != nil {
+		return "", "", "", err
+	}
+	volumeId, err := parseValue(lines[volumeIdOffset], "Volume ID:")
+	if err != nil {
+		return "", "", "", err
+	}
+	deviceName, err := parseValue(lines[deviceNameOffset], "Device Name:")
+	if err != nil {
+		return "", "", "", err
+	}
+	return diskNumber, volumeId, deviceName, nil
+}
+
+// parseValue looks for the volume information identifier and replaces it to return just the value
+func parseValue(inputBuffer string, stringToTrim string) (string, error) {
+	// if the input buffer doesn't have the identifier for the information, return an error
+	if !strings.Contains(inputBuffer, stringToTrim) {
+		return "", errors.New("output buffer was missing the string:" + stringToTrim)
+	}
+
+	return strings.TrimSpace(strings.Replace(inputBuffer, stringToTrim, "", -1)), nil
 }

--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -21,22 +21,20 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
 
 const (
-	volumeDiscoveryTimeoutDuration = 5 * time.Second
-	diskNumberOffset               = 0
-	volumeIdOffset                 = 1
-	deviceNameOffset               = 2
-	volumeInfoLength               = 3
+	diskNumberOffset = 0
+	volumeIdOffset   = 1
+	deviceNameOffset = 2
+	volumeInfoLength = 3
 )
 
-func (api EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
-	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, volumeDiscoveryTimeoutDuration)
+func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsVolumeDiscoveryTimeout)
 	defer cancel()
 	output, err := exec.CommandContext(ctxWithTimeout,
 		"C:\\PROGRAMDATA\\Amazon\\Tools\\ebsnvme-id.exe").CombinedOutput()

--- a/ecs-agent/api/resource/ebs_discovery.go
+++ b/ecs-agent/api/resource/ebs_discovery.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	ebsnvmeIDTimeoutDuration = 5 * time.Second
-	ebsResourceKeyPrefix     = "ebs-volume:"
-	ScanPeriod               = 500 * time.Millisecond
+	ebsVolumeDiscoveryTimeout = 5 * time.Second
+	ebsResourceKeyPrefix      = "ebs-volume:"
+	ScanPeriod                = 500 * time.Millisecond
 )
 
 var (

--- a/ecs-agent/api/resource/ebs_discovery.go
+++ b/ecs-agent/api/resource/ebs_discovery.go
@@ -15,10 +15,12 @@ package resource
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
+
+	"github.com/aws/amazon-ecs-agent/ecs-agent/logger"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -31,31 +33,37 @@ var (
 	ErrInvalidVolumeID = errors.New("EBS volume IDs do not match")
 )
 
-// EBSDiscoveryClient is used to scan and validate if an EBS volume is attached on the host instance.
 type EBSDiscoveryClient struct {
 	ctx context.Context
 }
 
-// NewDiscoveryClient creates a new EBSDiscoveryClient object
-func NewDiscoveryClient(ctx context.Context) EBSDiscovery {
+func NewDiscoveryClient(ctx context.Context) *EBSDiscoveryClient {
 	return &EBSDiscoveryClient{
 		ctx: ctx,
 	}
 }
 
 // ScanEBSVolumes will iterate through the entire list of pending EBS volume attachments within the agent state and checks if it's attached on the host.
-func ScanEBSVolumes[T GenericEBSAttachmentObject](pendingAttachments map[string]T, dc EBSDiscovery) []string {
+func ScanEBSVolumes[T GenericEBSAttachmentObject](t map[string]T, dc EBSDiscovery) []string {
 	var err error
 	var foundVolumes []string
-	for key, ebs := range pendingAttachments {
+	for key, ebs := range t {
 		volumeId := strings.TrimPrefix(key, ebsResourceKeyPrefix)
 		deviceName := ebs.GetAttachmentProperties(DeviceName)
 		err = dc.ConfirmEBSVolumeIsAttached(deviceName, volumeId)
 		if err != nil {
-			if !errors.Is(err, ErrInvalidVolumeID) {
-				err = fmt.Errorf("%w; failed to confirm if EBS volume is attached to the host", err)
+			if err == ErrInvalidVolumeID || errors.Cause(err) == ErrInvalidVolumeID {
+				logger.Warn("Found a different EBS volume attached to the host. Expected EBS volume:", logger.Fields{
+					"volumeId":   volumeId,
+					"deviceName": deviceName,
+				})
+			} else {
+				logger.Warn("Failed to confirm if EBS volume is attached to the host. ", logger.Fields{
+					"volumeId":   volumeId,
+					"deviceName": deviceName,
+					"error":      err,
+				})
 			}
-			ebs.SetError(err)
 			continue
 		}
 		foundVolumes = append(foundVolumes, key)

--- a/ecs-agent/api/resource/ebs_discovery_linux.go
+++ b/ecs-agent/api/resource/ebs_discovery_linux.go
@@ -44,7 +44,7 @@ type BDChild struct {
 // 2. On xen-based instance we only check by the device name.
 func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
 	var lsblkOut LsblkOutput
-	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsnvmeIDTimeoutDuration)
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsVolumeDiscoveryTimeout)
 	defer cancel()
 
 	// The lsblk command will output the name and volume ID of all block devices on the host in JSON format

--- a/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -16,6 +16,108 @@
 
 package resource
 
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/pkg/errors"
+)
+
+const (
+	volumeDiscoveryTimeoutDuration = 5 * time.Second
+	diskNumberOffset               = 0
+	volumeIdOffset                 = 1
+	deviceNameOffset               = 2
+	volumeInfoLength               = 3
+)
+
 func (api EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, volumeDiscoveryTimeoutDuration)
+	defer cancel()
+	output, err := exec.CommandContext(ctxWithTimeout,
+		"C:\\PROGRAMDATA\\Amazon\\Tools\\ebsnvme-id.exe").CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to run ebsnvme-id.exe: %s", string(output))
+	}
+
+	_, err = parseExecutableOutput(output, volumeID, deviceName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse ebsnvme-id.exe output for volumeID: %s and deviceName: %s",
+			volumeID, deviceName)
+	}
+
+	log.Info(fmt.Sprintf("found volume with volumeID: %s and deviceName: %s", volumeID, deviceName))
+
 	return nil
+}
+
+// parseExecutableOutput parses the output of `ebsnvme-id.exe` and returns the volumeId.
+func parseExecutableOutput(output []byte, candidateVolumeId string, candidateDeviceName string) (string, error) {
+	/* The output of the ebsnvme-id.exe is emitted like the following:
+	Disk Number: 0
+	Volume ID: vol-0a1234f340444abcd
+	Device Name: sda1
+
+	Disk Number: 1
+	Volume ID: vol-abcdef1234567890a
+	Device Name: /dev/sdf */
+
+	out := string(output)
+	// Replace double line with a single line and split based on single line
+	volumeInfo := strings.Split(strings.Replace(string(out), "\r\n\r\n", "\r\n", -1), "\r\n")
+
+	if len(volumeInfo) < volumeInfoLength {
+		return "", errors.New("cannot find the volume ID. Encountered error message: " + out)
+	}
+
+	//Read every 3 lines of disk information
+	for volumeIndex := 0; volumeIndex <= len(volumeInfo)-volumeInfoLength; volumeIndex = volumeIndex + volumeInfoLength {
+		_, volumeId, deviceName, err := parseSet(volumeInfo[volumeIndex : volumeIndex+volumeInfoLength])
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to parse the output for volumeID: %s and deviceName: %s. "+
+				"Output:%s", candidateVolumeId, candidateDeviceName, out)
+		}
+
+		if volumeId == candidateVolumeId && deviceName == candidateDeviceName {
+			return volumeId, nil
+		}
+
+	}
+
+	return "", errors.New("cannot find the volume ID:" + candidateVolumeId)
+}
+
+// parseSet parses the single volume information that is 3 lines long
+func parseSet(lines []string) (string, string, string, error) {
+	if len(lines) != 3 {
+		return "", "", "", errors.New("the number of entries in the volume information is insufficient to parse. Expected 3 lines")
+	}
+
+	diskNumber, err := parseValue(lines[diskNumberOffset], "Disk Number:")
+	if err != nil {
+		return "", "", "", err
+	}
+	volumeId, err := parseValue(lines[volumeIdOffset], "Volume ID:")
+	if err != nil {
+		return "", "", "", err
+	}
+	deviceName, err := parseValue(lines[deviceNameOffset], "Device Name:")
+	if err != nil {
+		return "", "", "", err
+	}
+	return diskNumber, volumeId, deviceName, nil
+}
+
+// parseValue looks for the volume information identifier and replaces it to return just the value
+func parseValue(inputBuffer string, stringToTrim string) (string, error) {
+	// if the input buffer doesn't have the identifier for the information, return an error
+	if !strings.Contains(inputBuffer, stringToTrim) {
+		return "", errors.New("output buffer was missing the string:" + stringToTrim)
+	}
+
+	return strings.TrimSpace(strings.Replace(inputBuffer, stringToTrim, "", -1)), nil
 }

--- a/ecs-agent/api/resource/ebs_discovery_windows.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows.go
@@ -21,22 +21,20 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	log "github.com/cihub/seelog"
 	"github.com/pkg/errors"
 )
 
 const (
-	volumeDiscoveryTimeoutDuration = 5 * time.Second
-	diskNumberOffset               = 0
-	volumeIdOffset                 = 1
-	deviceNameOffset               = 2
-	volumeInfoLength               = 3
+	diskNumberOffset = 0
+	volumeIdOffset   = 1
+	deviceNameOffset = 2
+	volumeInfoLength = 3
 )
 
-func (api EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
-	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, volumeDiscoveryTimeoutDuration)
+func (api *EBSDiscoveryClient) ConfirmEBSVolumeIsAttached(deviceName, volumeID string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(api.ctx, ebsVolumeDiscoveryTimeout)
 	defer cancel()
 	output, err := exec.CommandContext(ctxWithTimeout,
 		"C:\\PROGRAMDATA\\Amazon\\Tools\\ebsnvme-id.exe").CombinedOutput()

--- a/ecs-agent/api/resource/ebs_discovery_windows_test.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows_test.go
@@ -1,0 +1,87 @@
+//go:build windows && unit
+// +build windows,unit
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package resource
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testVolumeID = "vol-0a1234f340444abcd"
+	deviceName   = "/dev/sdf"
+)
+
+func Test_parseExecutableOutput_WithHappyPath(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(parsedOutput, testVolumeID))
+}
+
+func Test_parseExecutableOutput_WithMissingDiskNumber(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithMissingVolumeInformation(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nDevice Name: %s\r\n\r\n", deviceName)
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithMissingDeviceName(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\n\r\n", testVolumeID)
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithVolumeNameMismatch(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
+	parsedOutput, err := parseExecutableOutput([]byte(output), "MismatchedVolumeName", deviceName)
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithDeviceNameMismatch(t *testing.T) {
+	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, "MismatchedDeviceName")
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithTruncatedOutputBuffer(t *testing.T) {
+	output := "Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: TruncatedBuffer..."
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.Error(t, err)
+	assert.Equal(t, "", parsedOutput)
+}
+
+func Test_parseExecutableOutput_WithUnexpectedOutput(t *testing.T) {
+	output := "No EBS NVMe disks found."
+	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
+	require.Error(t, err, "cannot find the volume ID: %s", output)
+	assert.Equal(t, "", parsedOutput)
+}

--- a/ecs-agent/api/resource/ebs_discovery_windows_test.go
+++ b/ecs-agent/api/resource/ebs_discovery_windows_test.go
@@ -30,56 +30,56 @@ const (
 	deviceName   = "/dev/sdf"
 )
 
-func Test_parseExecutableOutput_WithHappyPath(t *testing.T) {
+func TestParseExecutableOutputWithHappyPath(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(parsedOutput, testVolumeID))
 }
 
-func Test_parseExecutableOutput_WithMissingDiskNumber(t *testing.T) {
+func TestParseExecutableOutputWithMissingDiskNumber(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithMissingVolumeInformation(t *testing.T) {
+func TestParseExecutableOutputWithMissingVolumeInformation(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nDevice Name: %s\r\n\r\n", deviceName)
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithMissingDeviceName(t *testing.T) {
+func TestParseExecutableOutputWithMissingDeviceName(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\n\r\n", testVolumeID)
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithVolumeNameMismatch(t *testing.T) {
+func TestParseExecutableOutputWithVolumeNameMismatch(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
 	parsedOutput, err := parseExecutableOutput([]byte(output), "MismatchedVolumeName", deviceName)
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithDeviceNameMismatch(t *testing.T) {
+func TestParseExecutableOutputWithDeviceNameMismatch(t *testing.T) {
 	output := fmt.Sprintf("Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: %s\r\nDevice Name: %s\r\n\r\n", testVolumeID, deviceName)
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, "MismatchedDeviceName")
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithTruncatedOutputBuffer(t *testing.T) {
+func TestParseExecutableOutputWithTruncatedOutputBuffer(t *testing.T) {
 	output := "Disk Number: 0\r\nVolume ID: vol-abcdef1234567890a\r\nDevice Name: sda1\r\n\r\nDisk Number: 1\r\nVolume ID: TruncatedBuffer..."
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err)
 	assert.Equal(t, "", parsedOutput)
 }
 
-func Test_parseExecutableOutput_WithUnexpectedOutput(t *testing.T) {
+func TestParseExecutableOutputWithUnexpectedOutput(t *testing.T) {
 	output := "No EBS NVMe disks found."
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err, "cannot find the volume ID: %s", output)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds the feature to detect an attached EBS volume for a EC2 Windows host.

### Implementation details
<!-- How are the changes implemented? -->

We used the `ebsnvme-id.exe` windows utility to detect the volume based on the volumeID. 

### Testing
<!-- How was this tested? -->
Five additional unit tests were added on how the `ebsnvme-id.exe` command output is handled by new code.
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
Added the ability to detect EBS volumes on Windows.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
